### PR TITLE
Update date and recalculate on grid delta change

### DIFF
--- a/Grid Analyzer/Grid Analyzer/ViewModels/CoinListViewModel.swift
+++ b/Grid Analyzer/Grid Analyzer/ViewModels/CoinListViewModel.swift
@@ -162,7 +162,7 @@ final class CoinListViewModel: ObservableObject {
         progressDetail = "Preparing display...".localized
         
         // If grid spacing changed, we need to recalculate
-        let needsRecalculation = abs(container.gridSpacing - settings.gridDelta) > 0.01
+        let needsRecalculation = container.gridSpacing != settings.gridDelta
         
         if needsRecalculation {
             // Need to recalculate with new grid spacing

--- a/Grid Analyzer/Grid Analyzer/Views/CoinListView.swift
+++ b/Grid Analyzer/Grid Analyzer/Views/CoinListView.swift
@@ -72,7 +72,7 @@ struct CoinListView: View {
                     }
                 } header: {
                     if let lastUpdate = viewModel.lastUpdateTime {
-                        Text("Updated %@".localized(with: lastUpdate.formatted(date: .omitted, time: .shortened)))
+                        Text("Updated %@".localized(with: formattedUpdateText(lastUpdate)))
                             .font(.caption)
                             .foregroundStyle(.secondary)
                             .textCase(nil)
@@ -152,6 +152,14 @@ struct CoinListView: View {
         formatter.timeStyle = .short
         formatter.dateStyle = .none
         return formatter
+    }
+
+    private func formattedUpdateText(_ date: Date) -> String {
+        if Calendar.current.isDateInToday(date) {
+            return date.formatted(date: .omitted, time: .shortened)
+        } else {
+            return date.formatted(date: .abbreviated, time: .shortened)
+        }
     }
 }
 


### PR DESCRIPTION
Display date with time for non-today updates and trigger recalculation on any grid delta change.

---
<a href="https://cursor.com/background-agent?bcId=bc-10ca256b-34fb-491d-b3f9-ba6043ce899b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-10ca256b-34fb-491d-b3f9-ba6043ce899b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

